### PR TITLE
generate UUIDs for occurrence IDs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/golang/protobuf v1.4.2
 	github.com/google/cel-go v0.6.0
 	github.com/google/go-cmp v0.5.2 // indirect
+	github.com/google/uuid v1.1.2
 	github.com/grafeas/grafeas v0.1.6
 	github.com/hashicorp/go-multierror v1.0.0
 	github.com/onsi/ginkgo v1.14.2

--- a/go/v1beta1/storage/elasticsearch.go
+++ b/go/v1beta1/storage/elasticsearch.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/golang/protobuf/proto"
+	"github.com/google/uuid"
 	"google.golang.org/protobuf/encoding/protojson"
 	"io"
 	"net/http"
@@ -448,6 +449,7 @@ func (es *ElasticsearchStorage) CreateOccurrence(ctx context.Context, projectID,
 	if o.CreateTime == nil {
 		o.CreateTime = ptypes.TimestampNow()
 	}
+	o.Name = fmt.Sprintf("projects/%s/occurrences/%s", projectID, uuid.New().String())
 
 	str, err := protojson.Marshal(proto.MessageV2(o))
 	if err != nil {
@@ -474,8 +476,6 @@ func (es *ElasticsearchStorage) CreateOccurrence(ctx context.Context, projectID,
 	}
 
 	log.Debug("elasticsearch response", zap.Any("response", esResponse))
-
-	o.Name = fmt.Sprintf("projects/%s/occurrences/%s", projectID, esResponse.Id)
 
 	return o, nil
 }

--- a/go/v1beta1/storage/elasticsearch.go
+++ b/go/v1beta1/storage/elasticsearch.go
@@ -506,6 +506,7 @@ func (es *ElasticsearchStorage) BatchCreateOccurrences(ctx context.Context, proj
 	// in total, this body will consist of (len(occurrences) * 2) JSON structures, separated by newlines, with a trailing newline at the end
 	var body bytes.Buffer
 	for _, occurrence := range occurrences {
+		occurrence.Name = fmt.Sprintf("projects/%s/occurrences/%s", projectId, uuid.New().String())
 		data, err := protojson.Marshal(proto.MessageV2(occurrence))
 		if err != nil {
 			return nil, []error{
@@ -555,7 +556,6 @@ func (es *ElasticsearchStorage) BatchCreateOccurrences(ctx context.Context, proj
 			continue
 		}
 
-		occurrence.Name = fmt.Sprintf("projects/%s/occurrences/%s", projectId, indexItem.Id)
 		createdOccurrences = append(createdOccurrences, occurrence)
 	}
 

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -851,7 +851,10 @@ var _ = Describe("elasticsearch storage", func() {
 					Expect(metadata.Index.Index).To(Equal(expectedOccurrencesIndex))
 				} else { // occurrence
 					occurrence := payload.(*pb.Occurrence)
-					Expect(occurrence).To(Equal(expectedOccurrences[(i-1)/2]))
+					expectedOccurrence := expectedOccurrences[(i-1)/2]
+					expectedOccurrence.Name = occurrence.Name
+
+					Expect(occurrence).To(Equal(expectedOccurrence))
 				}
 			}
 		})

--- a/go/v1beta1/storage/elasticsearch_test.go
+++ b/go/v1beta1/storage/elasticsearch_test.go
@@ -760,6 +760,16 @@ var _ = Describe("elasticsearch storage", func() {
 
 		It("should attempt to index the occurrence as a document", func() {
 			Expect(transport.receivedHttpRequests[0].URL.Path).To(Equal(fmt.Sprintf("/%s/_doc", expectedOccurrencesIndex)))
+
+			requestBody, err := ioutil.ReadAll(transport.receivedHttpRequests[0].Body)
+			Expect(err).ToNot(HaveOccurred())
+
+			indexedOccurrence := &pb.Occurrence{}
+			err = protojson.Unmarshal(requestBody, proto.MessageV2(indexedOccurrence))
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedOccurrence.Name = actualOccurrence.Name
+			Expect(indexedOccurrence).To(Equal(expectedOccurrence))
 		})
 
 		When("indexing the document fails", func() {
@@ -785,7 +795,7 @@ var _ = Describe("elasticsearch storage", func() {
 			It("should return the occurrence that was created", func() {
 				Expect(actualErr).ToNot(HaveOccurred())
 
-				expectedOccurrence.Name = fmt.Sprintf("projects/%s/occurrences/%s", expectedProjectId, expectedOccurrenceId)
+				expectedOccurrence.Name = actualOccurrence.Name
 				Expect(actualOccurrence).To(Equal(expectedOccurrence))
 			})
 		})


### PR DESCRIPTION
also, removing some unreachable code paths with useless error checking when marshalling well-known structs to JSON