### PR TITLE
Break out integration tests; add more tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,8 +22,10 @@ jobs:
   integration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Go
+        uses: actions/setup-go@v2
         with:
           go-version: '1.15'
       - name: Start services

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15'
       - name: Start services
         run: docker-compose up -d --build elasticsearch server
       - name: Run integration tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # grafeas-elasticsearch
 
+[![codecov](https://codecov.io/gh/liatrio/grafeas-elasticsearch/branch/main/graph/badge.svg)](https://codecov.io/gh/liatrio/grafeas-elasticsearch)
+![tests](https://github.com/liatrio/grafeas-elasticsearch/workflows/test/badge.svg)
+
+[Elasticsearch](https://www.elastic.co/elasticsearch/) storage backend for [Grafeas](https://grafeas.io/).
+
 ## Local Development
 
 ### Testing
@@ -9,11 +14,16 @@ All tests use [Gomega](https://onsi.github.io/gomega/) for assertions and matchi
 
 #### unit
 
+Unit tests live alongside production code in `go/` directory.
+
 `make test` will run unit tests, along with vet and fmt.
+
+`make mocks` will regenerate test mocks in `go/mocks` directory.
 
 #### integration
 
-Integration tests require Elasticsearch and a build of this project running.
+Integration tests are in the `test/` directory.
+These require Elasticsearch and a build of this project to be running.
 This is handled through `docker-compose`.
 
 1. `docker-compose up -d --build elasticsearch server`
@@ -21,4 +31,6 @@ This is handled through `docker-compose`.
     - Remove `--build` if you have already built the local images against the latest code.
    Skipping build will significantly improve startup time.
 1. `make integration`
+   - Can be continuously run between docker-compose resets.
+   Tests generate UUIDs for resources, to avoid collisions between runs.
 1. `docker-compose down`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # grafeas-elasticsearch
 
 [![codecov](https://codecov.io/gh/liatrio/grafeas-elasticsearch/branch/main/graph/badge.svg)](https://codecov.io/gh/liatrio/grafeas-elasticsearch)
-![tests](https://github.com/liatrio/grafeas-elasticsearch/workflows/test/badge.svg)
+![test](https://github.com/liatrio/grafeas-elasticsearch/workflows/test/badge.svg)
 
 [Elasticsearch](https://www.elastic.co/elasticsearch/) storage backend for [Grafeas](https://grafeas.io/).
 

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	golang.org/x/sys v0.0.0-20201118182958-a01c418693c7 // indirect
 	google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98
 	google.golang.org/grpc v1.33.1
-	google.golang.org/grpc/examples v0.0.0-20201209011439-fd32f6a4fefe // indirect
+	google.golang.org/grpc/examples v0.0.0-20201211171407-c638ab8ccda6 // indirect
 	google.golang.org/protobuf v1.25.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -436,8 +436,8 @@ google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1 h1:DGeFlSan2f+WEtCERJ4J9GJWk15TxUi8QGagfI87Xyc=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
-google.golang.org/grpc/examples v0.0.0-20201209011439-fd32f6a4fefe h1:w+Cib64DobhYVZki2ry/UoxHtAp63F7WwtoQ6W3ptio=
-google.golang.org/grpc/examples v0.0.0-20201209011439-fd32f6a4fefe/go.mod h1:Ly7ZA/ARzg8fnPU9TyZIxoz33sEUuWX7txiqs8lPTgE=
+google.golang.org/grpc/examples v0.0.0-20201211171407-c638ab8ccda6 h1:EZ0hz95G65YQYAisUeZxwyPAKnBJGCzC9rj/AZysDOs=
+google.golang.org/grpc/examples v0.0.0-20201211171407-c638ab8ccda6/go.mod h1:Ly7ZA/ARzg8fnPU9TyZIxoz33sEUuWX7txiqs8lPTgE=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -450,7 +450,6 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
-gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
@@ -465,7 +464,6 @@ gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bl
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -60,3 +60,7 @@ func CreateProject(s *Setup, n string) (*project_go_proto.Project, error) {
 		},
 	})
 }
+
+func RandomNoteName(project string) string {
+	return fmt.Sprintf("%s/notes/%s", project, fake.UUID())
+}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1,0 +1,62 @@
+package util
+
+import (
+	"context"
+	"fmt"
+	fake "github.com/brianvoe/gofakeit/v5"
+	"github.com/grafeas/grafeas/proto/v1beta1/grafeas_go_proto"
+	"github.com/grafeas/grafeas/proto/v1beta1/project_go_proto"
+	. "github.com/onsi/gomega"
+	"google.golang.org/grpc"
+	"log"
+	"testing"
+)
+
+type Setup struct {
+	Ctx context.Context
+	Gc  grafeas_go_proto.GrafeasV1Beta1Client
+	Pc  project_go_proto.ProjectsClient
+}
+
+func checkErrFatal(e error) {
+	if e != nil {
+		log.Fatalf("Failed to create test setup.\nError: %v", e)
+	}
+}
+
+func NewSetup() *Setup {
+	ctx := context.Background()
+
+	projectsCC, err := grpc.DialContext(ctx, "localhost:8080", grpc.WithInsecure())
+	checkErrFatal(err)
+
+	projectsClient := project_go_proto.NewProjectsClient(projectsCC)
+
+	grafeasCC, err := grpc.DialContext(ctx, "localhost:8080", grpc.WithInsecure())
+	checkErrFatal(err)
+
+	grafeasClient := grafeas_go_proto.NewGrafeasV1Beta1Client(grafeasCC)
+
+	return &Setup{
+		ctx,
+		grafeasClient,
+		projectsClient,
+	}
+}
+
+func NewExpect(t *testing.T) func(actual interface{}, extra ...interface{}) Assertion {
+	g := NewGomegaWithT(t)
+	return g.Expect
+}
+
+func RandomProjectName() string {
+	return fmt.Sprintf("projects/%s", fake.UUID())
+}
+
+func CreateProject(s *Setup, n string) (*project_go_proto.Project, error) {
+	return s.Pc.CreateProject(s.Ctx, &project_go_proto.CreateProjectRequest{
+		Project: &project_go_proto.Project{
+			Name: n,
+		},
+	})
+}

--- a/test/v1beta1/main_test.go
+++ b/test/v1beta1/main_test.go
@@ -1,188 +1,22 @@
 package v1beta1_test
 
 import (
-	"context"
-	"fmt"
+	"flag"
 	fake "github.com/brianvoe/gofakeit/v5"
-	"github.com/grafeas/grafeas/proto/v1beta1/build_go_proto"
-	"github.com/grafeas/grafeas/proto/v1beta1/grafeas_go_proto"
-	"github.com/grafeas/grafeas/proto/v1beta1/project_go_proto"
-	"github.com/grafeas/grafeas/proto/v1beta1/provenance_go_proto"
-	. "github.com/onsi/gomega"
-	"google.golang.org/grpc"
 	"log"
+	"os"
 	"testing"
 )
 
-type setup struct {
-	ctx context.Context
-	gc  grafeas_go_proto.GrafeasV1Beta1Client
-	pc  project_go_proto.ProjectsClient
-}
+func TestMain(m *testing.M) {
+	flag.Parse()
 
-func newSetup() (*setup, error) {
-	ctx := context.Background()
-
-	projectsCC, err := grpc.DialContext(ctx, "localhost:8080", grpc.WithInsecure())
-	if err != nil {
-		return nil, err
-	}
-	projectsClient := project_go_proto.NewProjectsClient(projectsCC)
-
-	grafeasCC, err := grpc.DialContext(ctx, "localhost:8080", grpc.WithInsecure())
-	if err != nil {
-		return nil, err
-	}
-	grafeasClient := grafeas_go_proto.NewGrafeasV1Beta1Client(grafeasCC)
-
-	return &setup{
-		ctx,
-		grafeasClient,
-		projectsClient,
-	}, nil
-}
-
-func TestGrafeasElasticsearch(t *testing.T) {
 	if testing.Short() {
-		t.Skipf("Test run with -short flag, skipping.")
+		log.Println("Test run with -short flag, skipping integration.")
+		os.Exit(0)
 	}
 
 	fake.Seed(0)
 
-	g := NewGomegaWithT(t)
-	Expect := g.Expect
-
-	s, err := newSetup()
-	if err != nil {
-		log.Fatalf("Failed to create test setup.\nError: %v", err)
-	}
-
-	t.Run("projects", func(t *testing.T) {
-		t.Run("creating a project", func(t *testing.T) {
-			t.Run("should succeed with a valid name", func(t *testing.T) {
-				name := randomProjectName()
-
-				p, err := createProject(s, name)
-				Expect(err).ToNot(HaveOccurred())
-
-				_, err = s.pc.GetProject(s.ctx, &project_go_proto.GetProjectRequest{Name: p.GetName()})
-				Expect(err).ToNot(HaveOccurred())
-			})
-		})
-
-		t.Run("listing projects", func(t *testing.T) {
-			type test struct {
-				name, filter string
-				expected     []string
-			}
-
-			names := []string{
-				"projects/foo",
-				"projects/bar",
-				"projects/foo-bar-123",
-			}
-
-			for _, n := range names {
-				_, err = createProject(s, n)
-				Expect(err).ToNot(HaveOccurred())
-			}
-
-			t.Run("filters", func(t *testing.T) {
-				for _, tc := range []test{
-					{
-						name:     "single exact name match",
-						filter:   "name==\"projects/foo\"",
-						expected: []string{"projects/foo"},
-					},
-					{
-						name:     "or exact name match",
-						filter:   "name==\"projects/foo\"||name==\"projects/bar\"",
-						expected: []string{"projects/foo", "projects/bar"},
-					},
-				} {
-					tc := tc
-
-					t.Run(tc.name, func(t *testing.T) {
-						t.Parallel()
-
-						response, err := s.pc.ListProjects(s.ctx, &project_go_proto.ListProjectsRequest{Filter: tc.filter})
-						Expect(err).ToNot(HaveOccurred())
-
-						Expect(len(response.Projects)).To(Equal(len(tc.expected)))
-						for _, p := range response.Projects {
-							Expect(p.GetName()).To(BeElementOf(tc.expected))
-						}
-					})
-				}
-			})
-
-			for _, n := range names {
-				_, err = s.pc.DeleteProject(s.ctx, &project_go_proto.DeleteProjectRequest{Name: n})
-				Expect(err).To(HaveOccurred())
-			}
-		})
-
-		t.Run("deleting a project", func(t *testing.T) {
-			t.Run("should successfully remove an existing project", func(t *testing.T) {
-				name := randomProjectName()
-
-				p, err := createProject(s, name)
-				Expect(err).ToNot(HaveOccurred())
-
-				// Currently Grafeas returns an error even on successful delete.
-				// This makes testing delete scenarios awkward.
-				// For now we ignore response on delete, and check for error on a subsequent lookup, assuming it won't be found.
-				//
-				// TODO: Once https://github.com/grafeas/grafeas/pull/468 is merged and released,
-				//   refactor this test to actual review delete results and expect
-
-				s.pc.DeleteProject(s.ctx, &project_go_proto.DeleteProjectRequest{Name: name})
-
-				_, err = s.pc.GetProject(s.ctx, &project_go_proto.GetProjectRequest{Name: p.GetName()})
-				Expect(err).To(HaveOccurred())
-			})
-		})
-	})
-
-	t.Run("occurrences", func(t *testing.T) {
-		t.Run("creating an occurrence", func(t *testing.T) {
-			projectName := randomProjectName()
-
-			_, err = createProject(s, projectName)
-			Expect(err).ToNot(HaveOccurred())
-
-			t.Run("should be successful", func(t *testing.T) {
-				o, err := s.gc.CreateOccurrence(s.ctx, &grafeas_go_proto.CreateOccurrenceRequest{
-					Parent: projectName,
-					Occurrence: &grafeas_go_proto.Occurrence{
-						Details: &grafeas_go_proto.Occurrence_Build{Build: &build_go_proto.Details{
-							Provenance: &provenance_go_proto.BuildProvenance{
-								Id: fake.UUID(),
-							},
-						}},
-						NoteName: fmt.Sprintf("%s/notes/%s", projectName, fake.AppName()),
-						Resource: &grafeas_go_proto.Resource{
-							Uri: fake.URL(),
-						},
-					},
-				})
-				Expect(err).ToNot(HaveOccurred())
-
-				_, err = s.gc.GetOccurrence(s.ctx, &grafeas_go_proto.GetOccurrenceRequest{Name: o.GetName()})
-				Expect(err).ToNot(HaveOccurred())
-			})
-		})
-	})
-}
-
-func randomProjectName() string {
-	return fmt.Sprintf("projects/%s", fake.UUID())
-}
-
-func createProject(s *setup, n string) (*project_go_proto.Project, error) {
-	return s.pc.CreateProject(s.ctx, &project_go_proto.CreateProjectRequest{
-		Project: &project_go_proto.Project{
-			Name: n,
-		},
-	})
+	os.Exit(m.Run())
 }

--- a/test/v1beta1/note_test.go
+++ b/test/v1beta1/note_test.go
@@ -1,0 +1,7 @@
+package v1beta1_test
+
+import "testing"
+
+func TestNote(t *testing.T) {
+	t.Skipf("TODO")
+}

--- a/test/v1beta1/occurrence_test.go
+++ b/test/v1beta1/occurrence_test.go
@@ -1,0 +1,47 @@
+package v1beta1_test
+
+import (
+	"fmt"
+	fake "github.com/brianvoe/gofakeit/v5"
+	"github.com/grafeas/grafeas/proto/v1beta1/build_go_proto"
+	"github.com/grafeas/grafeas/proto/v1beta1/grafeas_go_proto"
+	"github.com/grafeas/grafeas/proto/v1beta1/provenance_go_proto"
+	"github.com/liatrio/grafeas-elasticsearch/test/util"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestOccurrence(t *testing.T) {
+	Expect := util.NewExpect(t)
+	s := util.NewSetup()
+
+	t.Run("creating an occurrence", func(t *testing.T) {
+		t.Parallel()
+
+		projectName := util.RandomProjectName()
+
+		_, err := util.CreateProject(s, projectName)
+		Expect(err).ToNot(HaveOccurred())
+
+		t.Run("should be successful", func(t *testing.T) {
+			o, err := s.Gc.CreateOccurrence(s.Ctx, &grafeas_go_proto.CreateOccurrenceRequest{
+				Parent: projectName,
+				Occurrence: &grafeas_go_proto.Occurrence{
+					Details: &grafeas_go_proto.Occurrence_Build{Build: &build_go_proto.Details{
+						Provenance: &provenance_go_proto.BuildProvenance{
+							Id: fake.UUID(),
+						},
+					}},
+					NoteName: fmt.Sprintf("%s/notes/%s", projectName, fake.AppName()),
+					Resource: &grafeas_go_proto.Resource{
+						Uri: fake.URL(),
+					},
+				},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = s.Gc.GetOccurrence(s.Ctx, &grafeas_go_proto.GetOccurrenceRequest{Name: o.GetName()})
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+}

--- a/test/v1beta1/occurrence_test.go
+++ b/test/v1beta1/occurrence_test.go
@@ -1,11 +1,12 @@
 package v1beta1_test
 
 import (
-	"fmt"
 	fake "github.com/brianvoe/gofakeit/v5"
 	"github.com/grafeas/grafeas/proto/v1beta1/build_go_proto"
 	"github.com/grafeas/grafeas/proto/v1beta1/grafeas_go_proto"
+	"github.com/grafeas/grafeas/proto/v1beta1/package_go_proto"
 	"github.com/grafeas/grafeas/proto/v1beta1/provenance_go_proto"
+	"github.com/grafeas/grafeas/proto/v1beta1/vulnerability_go_proto"
 	"github.com/liatrio/grafeas-elasticsearch/test/util"
 	. "github.com/onsi/gomega"
 	"testing"
@@ -15,24 +16,24 @@ func TestOccurrence(t *testing.T) {
 	Expect := util.NewExpect(t)
 	s := util.NewSetup()
 
+	// setup project for occurrences
+	projectName := util.RandomProjectName()
+
+	_, err := util.CreateProject(s, projectName)
+	Expect(err).ToNot(HaveOccurred())
+
 	t.Run("creating an occurrence", func(t *testing.T) {
-		t.Parallel()
-
-		projectName := util.RandomProjectName()
-
-		_, err := util.CreateProject(s, projectName)
-		Expect(err).ToNot(HaveOccurred())
-
 		t.Run("should be successful", func(t *testing.T) {
 			o, err := s.Gc.CreateOccurrence(s.Ctx, &grafeas_go_proto.CreateOccurrenceRequest{
 				Parent: projectName,
 				Occurrence: &grafeas_go_proto.Occurrence{
-					Details: &grafeas_go_proto.Occurrence_Build{Build: &build_go_proto.Details{
-						Provenance: &provenance_go_proto.BuildProvenance{
-							Id: fake.UUID(),
-						},
-					}},
-					NoteName: fmt.Sprintf("%s/notes/%s", projectName, fake.AppName()),
+					Details: &grafeas_go_proto.Occurrence_Build{
+						Build: &build_go_proto.Details{
+							Provenance: &provenance_go_proto.BuildProvenance{
+								Id: fake.UUID(),
+							},
+						}},
+					NoteName: util.RandomNoteName(projectName),
 					Resource: &grafeas_go_proto.Resource{
 						Uri: fake.URL(),
 					},
@@ -43,5 +44,90 @@ func TestOccurrence(t *testing.T) {
 			_, err = s.Gc.GetOccurrence(s.Ctx, &grafeas_go_proto.GetOccurrenceRequest{Name: o.GetName()})
 			Expect(err).ToNot(HaveOccurred())
 		})
+	})
+
+	t.Run("batch creating occurrences", func(t *testing.T) {
+		bo, err := s.Gc.BatchCreateOccurrences(s.Ctx, &grafeas_go_proto.BatchCreateOccurrencesRequest{
+			Parent: projectName,
+			Occurrences: []*grafeas_go_proto.Occurrence{
+				{
+					Details: &grafeas_go_proto.Occurrence_Build{
+						Build: &build_go_proto.Details{
+							Provenance: &provenance_go_proto.BuildProvenance{
+								Id: fake.UUID(),
+							},
+						}},
+					NoteName: util.RandomNoteName(projectName),
+					Resource: &grafeas_go_proto.Resource{
+						Uri: fake.URL(),
+					},
+				},
+				{
+					Details: &grafeas_go_proto.Occurrence_Vulnerability{
+						Vulnerability: &vulnerability_go_proto.Details{
+							PackageIssue: []*vulnerability_go_proto.PackageIssue{
+								{
+									AffectedLocation: &vulnerability_go_proto.VulnerabilityLocation{
+										CpeUri:  fake.URL(),
+										Package: fake.AppName(),
+										Version: &package_go_proto.Version{
+											Name: fake.AppVersion(),
+											Kind: package_go_proto.Version_NORMAL,
+										},
+									},
+								},
+							},
+						},
+					},
+					NoteName: util.RandomNoteName(projectName),
+					Resource: &grafeas_go_proto.Resource{
+						Uri: fake.URL(),
+					},
+				},
+			},
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+
+		for _, o := range bo.Occurrences {
+			_, err = s.Gc.GetOccurrence(s.Ctx, &grafeas_go_proto.GetOccurrenceRequest{Name: o.GetName()})
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	t.Run("deleting an occurrence", func(t *testing.T) {
+		o, err := s.Gc.CreateOccurrence(s.Ctx, &grafeas_go_proto.CreateOccurrenceRequest{
+			Parent: projectName,
+			Occurrence: &grafeas_go_proto.Occurrence{
+				Details: &grafeas_go_proto.Occurrence_Build{
+					Build: &build_go_proto.Details{
+						Provenance: &provenance_go_proto.BuildProvenance{
+							Id: fake.UUID(),
+						},
+					}},
+				NoteName: util.RandomNoteName(projectName),
+				Resource: &grafeas_go_proto.Resource{
+					Uri: fake.URL(),
+				},
+			},
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		// Currently Grafeas returns an error even on successful delete.
+		// This makes testing delete scenarios awkward.
+		// For now we ignore response on delete, and check for error on a subsequent lookup, assuming it won't be found.
+		//
+		// TODO: Once a new version of Grafeas is released that contains this fix:
+		//  https://github.com/grafeas/grafeas/pull/456
+		//  This should be updated to actually review delete results
+
+		s.Gc.DeleteOccurrence(s.Ctx, &grafeas_go_proto.DeleteOccurrenceRequest{Name: o.Name})
+
+		_, err = s.Gc.GetOccurrence(s.Ctx, &grafeas_go_proto.GetOccurrenceRequest{Name: o.GetName()})
+		Expect(err).To(HaveOccurred())
+	})
+
+	t.Run("listing occurrences", func(t *testing.T) {
+		t.Skipf("TODO")
 	})
 }

--- a/test/v1beta1/project_test.go
+++ b/test/v1beta1/project_test.go
@@ -1,0 +1,97 @@
+package v1beta1_test
+
+import (
+	"github.com/grafeas/grafeas/proto/v1beta1/project_go_proto"
+	"github.com/liatrio/grafeas-elasticsearch/test/util"
+	. "github.com/onsi/gomega"
+	"testing"
+)
+
+func TestProject(t *testing.T) {
+	Expect := util.NewExpect(t)
+	s := util.NewSetup()
+
+	t.Run("creating a project", func(t *testing.T) {
+		t.Run("should succeed with a valid name", func(t *testing.T) {
+			name := util.RandomProjectName()
+
+			p, err := util.CreateProject(s, name)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = s.Pc.GetProject(s.Ctx, &project_go_proto.GetProjectRequest{Name: p.GetName()})
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	t.Run("listing projects", func(t *testing.T) {
+		names := []string{
+			"projects/foo",
+			"projects/bar",
+			"projects/foo-bar-123",
+		}
+
+		for _, n := range names {
+			_, err := util.CreateProject(s, n)
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		t.Run("filters", func(t *testing.T) {
+			for _, tc := range []struct {
+				name, filter string
+				expected     []string
+			}{
+				{
+					name:     "single exact name match",
+					filter:   "name==\"projects/foo\"",
+					expected: []string{"projects/foo"},
+				},
+				{
+					name:     "or exact name match",
+					filter:   "name==\"projects/foo\"||name==\"projects/bar\"",
+					expected: []string{"projects/foo", "projects/bar"},
+				},
+			} {
+				// ensure parallel tests are run with correct test case
+				tc := tc
+
+				t.Run(tc.name, func(t *testing.T) {
+					t.Parallel()
+
+					response, err := s.Pc.ListProjects(s.Ctx, &project_go_proto.ListProjectsRequest{Filter: tc.filter})
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(len(response.Projects)).To(Equal(len(tc.expected)))
+					for _, p := range response.Projects {
+						Expect(p.GetName()).To(BeElementOf(tc.expected))
+					}
+				})
+			}
+		})
+
+		for _, n := range names {
+			_, err := s.Pc.DeleteProject(s.Ctx, &project_go_proto.DeleteProjectRequest{Name: n})
+			Expect(err).To(HaveOccurred())
+		}
+	})
+
+	t.Run("deleting a project", func(t *testing.T) {
+		t.Run("should successfully remove an existing project", func(t *testing.T) {
+			name := util.RandomProjectName()
+
+			p, err := util.CreateProject(s, name)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Currently Grafeas returns an error even on successful delete.
+			// This makes testing delete scenarios awkward.
+			// For now we ignore response on delete, and check for error on a subsequent lookup, assuming it won't be found.
+			//
+			// TODO: Once https://github.com/grafeas/grafeas/pull/468 is merged and released,
+			//   refactor this test to actual review delete results and expect
+
+			s.Pc.DeleteProject(s.Ctx, &project_go_proto.DeleteProjectRequest{Name: name})
+
+			_, err = s.Pc.GetProject(s.Ctx, &project_go_proto.GetProjectRequest{Name: p.GetName()})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+}

--- a/test/v1beta1/project_test.go
+++ b/test/v1beta1/project_test.go
@@ -102,7 +102,7 @@ func TestProject(t *testing.T) {
 			// For now we ignore response on delete, and check for error on a subsequent lookup, assuming it won't be found.
 			//
 			// TODO: Once https://github.com/grafeas/grafeas/pull/468 is merged and released,
-			//   refactor this test to actual review delete results and expect
+			//   refactor this test to actually review delete results
 
 			s.Pc.DeleteProject(s.Ctx, &project_go_proto.DeleteProjectRequest{Name: name})
 


### PR DESCRIPTION
## Changes

- Break out single integration test to separate areas of functionality.
- Consolidate global setup into `TestMain`.
- Add more tests.
- Mark `TODO` tests for functionality not yet implemented.
- Add more information and badges to README.
- Specify version of Go used to run integration tests in CI.